### PR TITLE
launchpad.html must use id sap-ushell-bootstrap

### DIFF
--- a/packages/helloworld/ui5.yaml
+++ b/packages/helloworld/ui5.yaml
@@ -10,12 +10,12 @@ framework:
     - name: sap.ui.core
     - name: sap.ui.unified
     - name: themelib_sap_horizon
-#server:
-#  customMiddleware:
-#  - name: ui5-middleware-livereload
-#    afterMiddleware: compression
-#    configuration:
-#      debug: true
-#      extraExts: "xml,json,properties"
-#      port: 35729
-#      path: "webapp"
+server:
+ customMiddleware:
+ - name: ui5-middleware-livereload
+   afterMiddleware: compression
+   configuration:
+     debug: true
+     extraExts: "xml,json,properties"
+     port: 35729
+     path: "webapp"

--- a/packages/helloworld/webapp/launchpad.html
+++ b/packages/helloworld/webapp/launchpad.html
@@ -23,7 +23,7 @@
         },
       };
     </script>
-    <script src="https://sapui5.hana.ondemand.com/1.108.19/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
+    <script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/1.108.19/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
 
     <script
       id="sap-ui-bootstrap"


### PR DESCRIPTION
The `sandbox.js` must be identified with the `sap-ushell-boostrap` id to identify the root path of the `fioriSandboxConfig.json` from CDN. By adding the `id` it works now...

Fixes: https://github.com/ui5-community/ui5-ecosystem-showcase/issues/771